### PR TITLE
Scalars support

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -2774,6 +2774,7 @@ else:
             "T5_PRETRAINED_MODEL_ARCHIVE_LIST",
             "T5EncoderModel",
             "T5ForConditionalGeneration",
+            "T5ForConditionalGenerationGen2",
             "T5ForQuestionAnswering",
             "T5ForSequenceClassification",
             "T5Model",

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -2774,7 +2774,6 @@ else:
             "T5_PRETRAINED_MODEL_ARCHIVE_LIST",
             "T5EncoderModel",
             "T5ForConditionalGeneration",
-            "T5ForConditionalGenerationGen2",
             "T5ForQuestionAnswering",
             "T5ForSequenceClassification",
             "T5Model",

--- a/src/transformers/models/t5/configuration_t5.py
+++ b/src/transformers/models/t5/configuration_t5.py
@@ -103,7 +103,7 @@ class T5Config(PretrainedConfig):
         classifier_dropout=0.0,
         position_embedding_definitions=None,
         memory_efficient_attention: Optional[str]=None,
-        support_scalars_inputs: bool = False,
+        support_scalars: bool = False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -144,7 +144,7 @@ class T5Config(PretrainedConfig):
             #this configuration mimics the default T5 relative positional encoding behavior
             self.position_embedding_definitions = dict(default=dict(type='t5_default_relative', config=None))            
         self.memory_efficient_attention = memory_efficient_attention
-        self.support_scalars_inputs = support_scalars_inputs
+        self.support_scalars = support_scalars
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/t5/configuration_t5.py
+++ b/src/transformers/models/t5/configuration_t5.py
@@ -103,6 +103,7 @@ class T5Config(PretrainedConfig):
         classifier_dropout=0.0,
         position_embedding_definitions=None,
         memory_efficient_attention: Optional[str]=None,
+        support_scalars_inputs: bool = False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -143,6 +144,7 @@ class T5Config(PretrainedConfig):
             #this configuration mimics the default T5 relative positional encoding behavior
             self.position_embedding_definitions = dict(default=dict(type='t5_default_relative', config=None))            
         self.memory_efficient_attention = memory_efficient_attention
+        self.support_scalars_inputs = support_scalars_inputs
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1317,7 +1317,7 @@ class T5Stack(T5PreTrainedModel):
             if self.project_scalars is not None:
                 for sample_idx, (_curr_scalar_ind, _curr_scalar_vals) in enumerate(zip(encoder_input_scalars_indices, encoder_input_scalars_values)):
                     assert not ((_curr_scalar_ind is not None) ^ (_curr_scalar_vals is not None)) #must be neither or both
-                    if _curr_scalar_ind is not None:
+                    if (_curr_scalar_ind is not None) and (_curr_scalar_ind.shape[0] > 0):
                         inputs_embeds[sample_idx][_curr_scalar_ind] += self.project_scalars(_curr_scalar_vals[..., None])
                 
 

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -2226,17 +2226,6 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
             reordered_decoder_past = reordered_decoder_past + (reordered_layer_past_states,)
         return reordered_decoder_past
 
-
-
-
-
-
-
-
-    
-
-    
-
 @add_start_docstrings(
     "The bare T5 Model transformer outputting encoder's raw hidden-states without any specific head on top.",
     T5_START_DOCSTRING,

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1315,9 +1315,10 @@ class T5Stack(T5PreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
             if self.project_scalars is not None:
-                assert not ((encoder_input_scalars_indices is not None) ^ (encoder_input_scalars_values is not None)) #must be neither or both 
                 for sample_idx, (_curr_scalar_ind, _curr_scalar_vals) in enumerate(zip(encoder_input_scalars_indices, encoder_input_scalars_values)):
-                    inputs_embeds[sample_idx][_curr_scalar_ind] += self.project_scalars(_curr_scalar_vals[..., None])
+                    assert not ((_curr_scalar_ind is not None) ^ (_curr_scalar_vals is not None)) #must be neither or both
+                    if _curr_scalar_ind is not None:
+                        inputs_embeds[sample_idx][_curr_scalar_ind] += self.project_scalars(_curr_scalar_vals[..., None])
                 
 
         if position_ids_dict is None:
@@ -1899,7 +1900,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         self.model_dim = config.d_model
 
         self.shared = nn.Embedding(config.vocab_size, config.d_model)
-        if config.support_scalars_inputs:
+        if config.support_scalars:
             self.project_input_scalars = nn.Linear(1, config.d_model, bias=True) #bias?
                 
         encoder_config = copy.deepcopy(config)
@@ -2134,6 +2135,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
         lm_logits = self.lm_head(sequence_output)
 
+        #import ipdb;ipdb.set_trace()
         loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss(ignore_index=-100)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -1280,8 +1280,8 @@ class T5Stack(T5PreTrainedModel):
         output_hidden_states=None,
         return_dict=None,
         position_ids_dict='default', #None here means the user wants NO pos embedding of any kind.  'default' has the default T5 behavior
-        encoder_input_scalars_indices: Optional[torch.LongTensor] = None,
-        encoder_input_scalars_values: Optional[torch.FloatTensor] = None,
+        encoder_input_scalars_indices: Optional[List[Optional[torch.LongTensor]]] = None,
+        encoder_input_scalars_values: Optional[List[Optional[torch.FloatTensor]]] = None,
     ):
         if position_ids_dict == 'default':
             position_ids_dict = {'default': (None, ["default"])} 
@@ -1315,7 +1315,7 @@ class T5Stack(T5PreTrainedModel):
                 raise ValueError("You have to initialize the model with valid token embeddings")
             inputs_embeds = self.embed_tokens(input_ids)
 
-            if self.project_scalars is not None:
+            if (self.project_scalars is not None) and (encoder_input_scalars_indices is not None) and (encoder_input_scalars_values is not None)):
                 for sample_idx, (_curr_scalar_ind, _curr_scalar_vals) in enumerate(zip(encoder_input_scalars_indices, encoder_input_scalars_values)):
                     assert not ((_curr_scalar_ind is not None) ^ (_curr_scalar_vals is not None)) #must be neither or both
                     if (_curr_scalar_ind is not None) and (_curr_scalar_ind.shape[0] > 0):
@@ -2003,8 +2003,8 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
         return_dict: Optional[bool] = None,
         encoder_position_ids_dict: Optional[Dict[str, Tuple[torch.LongTensor,str]]] = None,  # shape of each LongTensor (num_batches, n_input_tokens)
         decoder_position_ids_dict: Optional[Dict[str, Tuple[torch.LongTensor,str]]] = None, # shape of each LongTensor (num_batches, n_input_tokens)
-        encoder_input_scalars_indices: Optional[torch.LongTensor] = None,
-        encoder_input_scalars_values: Optional[torch.FloatTensor] = None,
+        encoder_input_scalars_indices: Optional[List[Optional[torch.LongTensor]]] = None,
+        encoder_input_scalars_values: Optional[List[Optional[torch.FloatTensor]]] = None,
     ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
@@ -2136,7 +2136,7 @@ class T5ForConditionalGeneration(T5PreTrainedModel):
 
         lm_logits = self.lm_head(sequence_output)
 
-        #import ipdb;ipdb.set_trace()
+        
         loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss(ignore_index=-100)


### PR DESCRIPTION
added support for scalars as inputs

a 1 -> model_dim projection is learned, used on the inputs, and added (*not* concatenated) on top of the tokens embeddings, only to input elements that have scalar input.


